### PR TITLE
fix: update npm publish workflow to handle file references

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,28 +76,6 @@ jobs:
       - name: Build all packages
         run: npm run build
       
-      - name: Update package.json for publishing
-        run: |
-          # Get version from tag or input
-          if [[ "${{ github.event_name }}" == "push" ]]; then
-            VERSION=${GITHUB_REF#refs/tags/v}
-          else
-            VERSION="${{ github.event.inputs.version }}"
-          fi
-          
-          # Replace file: references with proper npm versions for publishing
-          for pkg in packages/*/package.json packages/adapters/*/package.json; do
-            if [ -f "$pkg" ]; then
-              # Replace file: references with versioned dependencies
-              sed -i "s|\"file:../../core\"|\"^$VERSION\"|g" "$pkg"
-              sed -i "s|\"file:../core\"|\"^$VERSION\"|g" "$pkg"
-              sed -i "s|\"file:../query-parser\"|\"^$VERSION\"|g" "$pkg"
-              
-              echo "Updated $pkg for publishing"
-              cat "$pkg" | grep "@liquescent" || true
-            fi
-          done
-      
       - name: Run tests
         run: npm test
       
@@ -116,6 +94,69 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       
+      - name: Prepare packages for npm publish
+        run: |
+          # Get version from tag or input
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            VERSION=${GITHUB_REF#refs/tags/v}
+          else
+            VERSION="${{ github.event.inputs.version }}"
+          fi
+          
+          echo "Preparing packages for version $VERSION"
+          
+          # Create temporary directory for publishing
+          mkdir -p temp-publish
+          
+          # Function to prepare a package for publishing
+          prepare_package() {
+            local src_dir=$1
+            local pkg_name=$2
+            
+            # Copy package to temp directory
+            cp -r "$src_dir" "temp-publish/$pkg_name"
+            
+            # Update package.json with actual version dependencies
+            cd "temp-publish/$pkg_name"
+            
+            # Replace file: references with version references
+            if [ -f package.json ]; then
+              # Use Node.js to properly update the JSON
+              node -e "
+                const fs = require('fs');
+                const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+                
+                if (pkg.dependencies) {
+                  // Replace file: references with version references
+                  if (pkg.dependencies['@liquescent/log-correlator-core']) {
+                    if (pkg.dependencies['@liquescent/log-correlator-core'].startsWith('file:')) {
+                      pkg.dependencies['@liquescent/log-correlator-core'] = '$VERSION';
+                    }
+                  }
+                  if (pkg.dependencies['@liquescent/log-correlator-query-parser']) {
+                    if (pkg.dependencies['@liquescent/log-correlator-query-parser'].startsWith('file:')) {
+                      pkg.dependencies['@liquescent/log-correlator-query-parser'] = '$VERSION';
+                    }
+                  }
+                }
+                
+                fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\\n');
+              "
+              
+              echo "Prepared $pkg_name for publishing"
+              cat package.json | grep "@liquescent" || true
+            fi
+            
+            cd ../..
+          }
+          
+          # Prepare all packages
+          prepare_package "packages/query-parser" "query-parser"
+          prepare_package "packages/core" "core"
+          prepare_package "packages/adapters/loki" "loki"
+          prepare_package "packages/adapters/graylog" "graylog"
+          prepare_package "packages/adapters/promql" "promql"
+      
       - name: Publish packages
         run: |
           # Determine tag
@@ -133,17 +174,17 @@ jobs:
           
           echo "Publishing with tag: $TAG"
           
-          # Publish in dependency order
+          # Publish from temp directory in dependency order
           # 1. Query parser (no internal deps)
-          npm publish packages/query-parser --access public --tag $TAG
+          npm publish temp-publish/query-parser --access public --tag $TAG
           
           # 2. Core (depends on query-parser)
-          npm publish packages/core --access public --tag $TAG
+          npm publish temp-publish/core --access public --tag $TAG
           
           # 3. Adapters (depend on core)
-          npm publish packages/adapters/loki --access public --tag $TAG
-          npm publish packages/adapters/graylog --access public --tag $TAG
-          npm publish packages/adapters/promql --access public --tag $TAG
+          npm publish temp-publish/loki --access public --tag $TAG
+          npm publish temp-publish/graylog --access public --tag $TAG
+          npm publish temp-publish/promql --access public --tag $TAG
           
           echo "✅ All packages published successfully!"
         env:


### PR DESCRIPTION
## Summary
- Fixes the GitHub Actions publish workflow that was failing with git error
- npm was trying to resolve `file:` references as git repositories during publish

## Changes
- Create temporary directory with modified package.json files for publishing
- Replace `file:` references with actual version numbers only in the publish copies
- Keep original package.json files unchanged for local development
- Publish from the temporary directory instead of the source directories

## Test plan
- [x] Workflow changes reviewed
- [ ] Will be tested when tag is pushed after merge

Fixes the npm publish error:
```
npm error code 128
npm error An unknown git error occurred
npm error command git --no-replace-objects ls-remote ssh://git@github.com/packages/query-parser.git
```