### PR TITLE
fix: include examples package in version bump script

### DIFF
--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liquescent/log-correlator-examples",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "description": "Usage examples for log-correlator",
   "scripts": {

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -22,6 +22,7 @@ const PACKAGES = [
   "packages/adapters/loki",
   "packages/adapters/graylog",
   "packages/adapters/promql",
+  "packages/examples",
 ];
 
 // Internal package dependencies - kept for future use


### PR DESCRIPTION
## Summary
- Examples package version was not being updated by the bump-version script
- This caused the publish workflow to fail due to version mismatch

## Changes
- Added examples package to the PACKAGES array in bump-version.js
- Updated examples package.json to version 0.0.2 to match other packages

## Test plan
- [x] Version bump script now includes examples package
- [ ] Publish workflow will succeed after merge