### PR TITLE
fix: use cd to navigate to temp directories for npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -176,15 +176,15 @@ jobs:
           
           # Publish from temp directory in dependency order
           # 1. Query parser (no internal deps)
-          npm publish temp-publish/query-parser --access public --tag $TAG
+          cd temp-publish/query-parser && npm publish --access public --tag $TAG && cd ../..
           
           # 2. Core (depends on query-parser)
-          npm publish temp-publish/core --access public --tag $TAG
+          cd temp-publish/core && npm publish --access public --tag $TAG && cd ../..
           
           # 3. Adapters (depend on core)
-          npm publish temp-publish/loki --access public --tag $TAG
-          npm publish temp-publish/graylog --access public --tag $TAG
-          npm publish temp-publish/promql --access public --tag $TAG
+          cd temp-publish/loki && npm publish --access public --tag $TAG && cd ../..
+          cd temp-publish/graylog && npm publish --access public --tag $TAG && cd ../..
+          cd temp-publish/promql && npm publish --access public --tag $TAG && cd ../..
           
           echo "✅ All packages published successfully!"
         env:


### PR DESCRIPTION
## Summary
- npm was interpreting the path as a git repository instead of a local directory
- Fixed by using cd to navigate into the directory before publishing

## Changes
- Changed from `npm publish temp-publish/package` to `cd temp-publish/package && npm publish`

## Test plan
- [x] Workflow syntax is valid
- [ ] Will be tested when tag is pushed after merge

Fixes the npm publish error:
```
npm error code 128
npm error command git --no-replace-objects ls-remote ssh://git@github.com/temp-publish/query-parser.git
```