### PR TITLE
fix: handle existing GitHub releases gracefully

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -204,8 +204,23 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       
-      - name: Create GitHub Release
+      - name: Check if release exists
         if: github.event_name == 'push'  # Only for tag pushes
+        id: check_release
+        run: |
+          TAG_NAME="${{ github.ref_name }}"
+          if gh release view "$TAG_NAME" >/dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "✅ Release $TAG_NAME already exists, skipping creation"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "📝 Release $TAG_NAME does not exist, will create it"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Create GitHub Release
+        if: github.event_name == 'push' && steps.check_release.outputs.exists == 'false'
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ github.ref }}


### PR DESCRIPTION
## Summary
Fixes the GitHub Release creation error when re-running the publish workflow.

## Problem
When re-running the publish workflow (e.g., after fixing npm token), it fails with:
```
⚠️ GitHub release failed with status: 422
[{"resource":"Release","code":"already_exists","field":"tag_name"}]
❌ Too many retries. Aborting...
```

## Solution
Add a check to see if the release already exists before attempting to create it.

## Changes
- Add a step to check if the release exists using `gh release view`
- Only create the release if it doesn't already exist
- Log whether we're skipping or creating the release

## Success!
The v0.0.2 release has been successfully published to npm! 🎉

All packages are now available:
- @liquescent/log-correlator-query-parser: 0.0.2
- @liquescent/log-correlator-core: 0.0.2
- @liquescent/log-correlator-loki: 0.0.2
- @liquescent/log-correlator-graylog: 0.0.2
- @liquescent/log-correlator-promql: 0.0.2

## Test plan
- [x] Workflow syntax is valid
- [ ] Will be tested on next release or workflow re-run