### PR TITLE
chore: bump version to 0.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5602,7 +5602,7 @@
     },
     "packages/adapters/graylog": {
       "name": "@liquescent/log-correlator-graylog",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "AGPL-3.0",
       "dependencies": {
         "@liquescent/log-correlator-core": "file:../../core",
@@ -5620,7 +5620,7 @@
     },
     "packages/adapters/loki": {
       "name": "@liquescent/log-correlator-loki",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "AGPL-3.0",
       "dependencies": {
         "@liquescent/log-correlator-core": "file:../../core",
@@ -5640,7 +5640,7 @@
     },
     "packages/adapters/promql": {
       "name": "@liquescent/log-correlator-promql",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "AGPL-3.0",
       "dependencies": {
         "@liquescent/log-correlator-core": "file:../../core",
@@ -5657,7 +5657,7 @@
     },
     "packages/core": {
       "name": "@liquescent/log-correlator-core",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "AGPL-3.0",
       "dependencies": {
         "@liquescent/log-correlator-query-parser": "file:../query-parser",
@@ -5683,7 +5683,7 @@
     },
     "packages/examples": {
       "name": "@liquescent/log-correlator-examples",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "dependencies": {
         "@liquescent/log-correlator-core": "file:../core",
         "@liquescent/log-correlator-graylog": "file:../adapters/graylog",
@@ -5692,7 +5692,7 @@
     },
     "packages/query-parser": {
       "name": "@liquescent/log-correlator-query-parser",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "AGPL-3.0",
       "dependencies": {
         "@liquescent/log-correlator-core": "file:../core",

--- a/packages/adapters/graylog/package.json
+++ b/packages/adapters/graylog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liquescent/log-correlator-graylog",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Graylog adapter for log-correlator",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/adapters/loki/package.json
+++ b/packages/adapters/loki/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liquescent/log-correlator-loki",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Loki adapter for log-correlator",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/adapters/promql/package.json
+++ b/packages/adapters/promql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liquescent/log-correlator-promql",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "PromQL adapter for log-correlator",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liquescent/log-correlator-core",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Core correlation engine for real-time log stream processing",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liquescent/log-correlator-examples",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": true,
   "description": "Usage examples for log-correlator",
   "scripts": {

--- a/packages/query-parser/package.json
+++ b/packages/query-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liquescent/log-correlator-query-parser",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "PromQL-style query parser for log correlation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Bump all package versions to 0.0.6 to prepare for release.

## Changes
- All packages bumped from 0.0.5 to 0.0.6
- Includes Graylog v6 API fix from PR #26

## Release Notes
- Fixed Graylog v6 API request structure to properly support Graylog 6.x instances
- Corrected nested query_string structure and CSV response handling
- Enhanced documentation for v6 API usage

After merge, tag v0.0.6 will be created to trigger npm publish.