### PR TITLE
chore: bump version to 0.0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ A TypeScript npm package that enables real-time correlation of log streams from 
 
 ## Installation
 
-> ⚠️ **Pre-release Software**: This is version 0.0.6 - API may change significantly before 1.0.0
+> ⚠️ **Pre-release Software**: This is version 0.0.7 - API may change significantly before 1.0.0
 
 ```bash
-npm install @liquescent/log-correlator-core@^0.0.6
-npm install @liquescent/log-correlator-loki@^0.0.6     # Optional: Loki adapter
-npm install @liquescent/log-correlator-graylog@^0.0.6  # Optional: Graylog adapter
+npm install @liquescent/log-correlator-core@^0.0.7
+npm install @liquescent/log-correlator-loki@^0.0.7     # Optional: Loki adapter
+npm install @liquescent/log-correlator-graylog@^0.0.7  # Optional: Graylog adapter
 ```
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -96,28 +96,117 @@ for await (const correlation of engine.correlate(query)) {
 
 The package supports a PromQL-inspired syntax for correlating log streams:
 
-### Basic Join
+### Basic Join Operations
+
+#### Inner Join (AND)
+Finds events that exist in both streams:
 
 ```promql
 loki({service="frontend"})[5m]
   and on(request_id)
   loki({service="backend"})[5m]
+```
+
+#### Left Join (OR)
+Includes all events from the left stream, with matching events from the right:
+
+```promql
+graylog(service:payment)[10m]
+  or on(transaction_id)
+  graylog(service:notification)[10m]
+```
+
+#### Anti-Join (UNLESS)
+Events from the left stream that have no match in the right:
+
+```promql
+loki({service="api"})[5m]
+  unless on(request_id)
+  loki({service="database"})[5m]
+```
+
+### Graylog-Specific Examples
+
+#### Basic Graylog Query
+```promql
+graylog(application:webserver AND level:ERROR)[5m]
+```
+
+#### Graylog with Stream Name (v0.0.7+)
+```javascript
+// Configure adapter with stream name
+const adapter = new GraylogAdapter({
+  url: "http://graylog:9000",
+  apiToken: "token",
+  streamName: "Production Logs" // New in v0.0.7
+});
+
+// Query will automatically filter to this stream
+const query = 'graylog(service:api)[5m]';
+```
+
+#### Complex Graylog Correlation
+```promql
+# Correlate errors with their originating requests
+graylog(level:ERROR AND service:backend)[30m]
+  and on(correlation_id)
+  graylog(service:frontend AND path:"/api/*")[30m]
+```
+
+#### Multi-Service Trace Correlation
+```promql
+# Three-way correlation across microservices
+graylog(service:api-gateway)[10m]
+  and on(trace_id)
+  graylog(service:auth-service)[10m]
+  and on(trace_id)
+  graylog(service:user-service)[10m]
 ```
 
 ### Cross-Source Correlation
 
+#### Loki and Graylog Together
 ```promql
-loki({job="nginx"})[5m]
+# Correlate Kubernetes logs (Loki) with application logs (Graylog)
+loki({namespace="production", pod=~"api-.*"})[5m]
   and on(request_id)
-  graylog(service:api)[5m]
+  graylog(application:api AND environment:production)[5m]
 ```
 
-### Temporal Join
+#### With Custom Field Mapping
+```promql
+# Map different field names between sources
+loki({job="nginx"})[5m]
+  and on(req_id=request_id)
+  graylog(service:backend)[5m]
+```
+
+### Advanced Features
+
+#### Temporal Join with Time Window
+Events must occur within a specific time window:
 
 ```promql
 loki({service="frontend"})[5m]
-  and on(request_id) within(30s)
+  and on(session_id) within(30s)
   loki({service="backend"})[5m]
+```
+
+#### Group Modifiers
+Control how multiple matches are handled:
+
+```promql
+# Many-to-one correlation
+graylog(service:loadbalancer)[5m]
+  and on(backend_id) group_left()
+  graylog(service:backend)[5m]
+```
+
+#### Ignoring Specific Labels
+```promql
+loki({service="api"})[5m]
+  and ignoring(timestamp, hostname)
+  loki({service="database"})[5m]
 ```
 
 ## SOCKS Proxy Configuration

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ The package supports a PromQL-inspired syntax for correlating log streams:
 ### Basic Join Operations
 
 #### Inner Join (AND)
+
 Finds events that exist in both streams:
 
 ```promql
@@ -108,6 +109,7 @@ loki({service="frontend"})[5m]
 ```
 
 #### Left Join (OR)
+
 Includes all events from the left stream, with matching events from the right:
 
 ```promql
@@ -117,6 +119,7 @@ graylog(service:payment)[10m]
 ```
 
 #### Anti-Join (UNLESS)
+
 Events from the left stream that have no match in the right:
 
 ```promql
@@ -128,24 +131,27 @@ loki({service="api"})[5m]
 ### Graylog-Specific Examples
 
 #### Basic Graylog Query
+
 ```promql
 graylog(application:webserver AND level:ERROR)[5m]
 ```
 
 #### Graylog with Stream Name (v0.0.7+)
+
 ```javascript
 // Configure adapter with stream name
 const adapter = new GraylogAdapter({
   url: "http://graylog:9000",
   apiToken: "token",
-  streamName: "Production Logs" // New in v0.0.7
+  streamName: "Production Logs", // New in v0.0.7
 });
 
 // Query will automatically filter to this stream
-const query = 'graylog(service:api)[5m]';
+const query = "graylog(service:api)[5m]";
 ```
 
 #### Complex Graylog Correlation
+
 ```promql
 # Correlate errors with their originating requests
 graylog(level:ERROR AND service:backend)[30m]
@@ -154,6 +160,7 @@ graylog(level:ERROR AND service:backend)[30m]
 ```
 
 #### Multi-Service Trace Correlation
+
 ```promql
 # Three-way correlation across microservices
 graylog(service:api-gateway)[10m]
@@ -166,6 +173,7 @@ graylog(service:api-gateway)[10m]
 ### Cross-Source Correlation
 
 #### Loki and Graylog Together
+
 ```promql
 # Correlate Kubernetes logs (Loki) with application logs (Graylog)
 loki({namespace="production", pod=~"api-.*"})[5m]
@@ -174,6 +182,7 @@ loki({namespace="production", pod=~"api-.*"})[5m]
 ```
 
 #### With Custom Field Mapping
+
 ```promql
 # Map different field names between sources
 loki({job="nginx"})[5m]
@@ -184,6 +193,7 @@ loki({job="nginx"})[5m]
 ### Advanced Features
 
 #### Temporal Join with Time Window
+
 Events must occur within a specific time window:
 
 ```promql
@@ -193,6 +203,7 @@ loki({service="frontend"})[5m]
 ```
 
 #### Group Modifiers
+
 Control how multiple matches are handled:
 
 ```promql
@@ -203,6 +214,7 @@ graylog(service:loadbalancer)[5m]
 ```
 
 #### Ignoring Specific Labels
+
 ```promql
 loki({service="api"})[5m]
   and ignoring(timestamp, hostname)

--- a/package-lock.json
+++ b/package-lock.json
@@ -5602,7 +5602,7 @@
     },
     "packages/adapters/graylog": {
       "name": "@liquescent/log-correlator-graylog",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "AGPL-3.0",
       "dependencies": {
         "@liquescent/log-correlator-core": "file:../../core",
@@ -5620,7 +5620,7 @@
     },
     "packages/adapters/loki": {
       "name": "@liquescent/log-correlator-loki",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "AGPL-3.0",
       "dependencies": {
         "@liquescent/log-correlator-core": "file:../../core",
@@ -5640,7 +5640,7 @@
     },
     "packages/adapters/promql": {
       "name": "@liquescent/log-correlator-promql",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "AGPL-3.0",
       "dependencies": {
         "@liquescent/log-correlator-core": "file:../../core",
@@ -5657,7 +5657,7 @@
     },
     "packages/core": {
       "name": "@liquescent/log-correlator-core",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "AGPL-3.0",
       "dependencies": {
         "@liquescent/log-correlator-query-parser": "file:../query-parser",
@@ -5683,7 +5683,7 @@
     },
     "packages/examples": {
       "name": "@liquescent/log-correlator-examples",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "dependencies": {
         "@liquescent/log-correlator-core": "file:../core",
         "@liquescent/log-correlator-graylog": "file:../adapters/graylog",
@@ -5692,7 +5692,7 @@
     },
     "packages/query-parser": {
       "name": "@liquescent/log-correlator-query-parser",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "AGPL-3.0",
       "dependencies": {
         "@liquescent/log-correlator-core": "file:../core",

--- a/packages/adapters/graylog/README.md
+++ b/packages/adapters/graylog/README.md
@@ -5,8 +5,14 @@ This adapter enables the Log Correlator to connect to and consume logs from Gray
 ## Installation
 
 ```bash
-npm install @liquescent/log-correlator-graylog
+npm install @liquescent/log-correlator-graylog@^0.0.7
 ```
+
+## What's New in v0.0.7
+
+- **Stream Name Support**: Filter logs by human-readable stream names instead of IDs
+- **Enhanced Security**: Complete elimination of ReDoS vulnerabilities
+- **Improved Query Sanitization**: Robust handling of malformed queries without regex
 
 ## Supported Graylog Versions
 
@@ -30,13 +36,13 @@ const legacyAdapter = new GraylogAdapter({
   timeout: 15000, // 15 second timeout
 });
 
-// For Graylog 6.x+ with stream filtering by name
+// For Graylog 6.x+ with stream filtering by name (New in v0.0.7!)
 const v6Adapter = new GraylogAdapter({
   url: "http://graylog.example.com:9000",
   apiToken: "your-api-token", // API token recommended for v6
   apiVersion: "v6", // Required for Graylog 6.x
   pollInterval: 2000,
-  streamName: "Application Logs", // Filter by human-readable stream name
+  streamName: "Application Logs", // NEW: Filter by human-readable stream name
 });
 
 // Or use stream ID directly if you know it (24-char MongoDB ObjectId)
@@ -144,14 +150,15 @@ const { GraylogAdapter } = require("@liquescent/log-correlator-graylog");
 
 const engine = new CorrelationEngine();
 
-// Add Graylog adapter
+// Add Graylog adapter with stream name filtering (v0.0.7+)
 engine.addAdapter(
   "graylog",
   new GraylogAdapter({
     url: "http://graylog.example.com:9000",
     apiToken: "your-token",
     apiVersion: "v6", // Use v6 API for Graylog 6.x+ (returns CSV)
-    streamId: "optional-stream-id", // Filter by specific stream if needed
+    streamName: "Production Logs", // NEW in v0.0.7: Use human-readable name!
+    // streamId: "507f1f77bcf86cd799439011", // Alternative: use stream ID directly
   }),
 );
 
@@ -179,10 +186,30 @@ for await (const event of engine.correlate(correlationQuery)) {
 - **Polling-based streaming**: Continuously polls for new log messages
 - **Automatic retry**: Handles transient failures with exponential backoff
 - **Join key extraction**: Automatically extracts correlation IDs from log messages
-- **Stream filtering**: Filter logs by stream name or ID
+- **Stream filtering**: Filter logs by stream name or ID (v0.0.7+ supports names!)
 - **Time window support**: Configure time ranges for log queries
-- **Stream name resolution**: Automatically converts stream names to IDs
+- **Stream name resolution**: Automatically converts stream names to IDs (v0.0.7+)
 - **Correlation support**: Works seamlessly with the CorrelationEngine for complex correlation queries
+
+## Stream Name Support (v0.0.7+)
+
+The adapter now supports filtering by human-readable stream names instead of MongoDB ObjectIDs:
+
+```javascript
+// Before v0.0.7 - required stream ID
+const adapter = new GraylogAdapter({
+  streamId: "507f1f77bcf86cd799439011", // Hard to remember!
+});
+
+// v0.0.7+ - use stream names
+const adapter = new GraylogAdapter({
+  streamName: "Production Logs", // Much better!
+});
+
+// The adapter automatically resolves the name to ID
+// If multiple streams have the same name, the first match is used
+// Stream resolution happens once at adapter initialization
+```
 
 ## Correlation Query Support
 

--- a/packages/adapters/graylog/package.json
+++ b/packages/adapters/graylog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liquescent/log-correlator-graylog",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Graylog adapter for log-correlator",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/adapters/loki/package.json
+++ b/packages/adapters/loki/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liquescent/log-correlator-loki",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Loki adapter for log-correlator",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/adapters/promql/package.json
+++ b/packages/adapters/promql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liquescent/log-correlator-promql",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "PromQL adapter for log-correlator",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liquescent/log-correlator-core",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Core correlation engine for real-time log stream processing",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liquescent/log-correlator-examples",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "private": true,
   "description": "Usage examples for log-correlator",
   "scripts": {

--- a/packages/query-parser/README.md
+++ b/packages/query-parser/README.md
@@ -14,7 +14,7 @@ PromQL-inspired query parser for log correlation with full support for native Gr
 ## Installation
 
 ```bash
-npm install @liquescent/log-correlator-query-parser
+npm install @liquescent/log-correlator-query-parser@^0.0.7
 ```
 
 ## Usage

--- a/packages/query-parser/package.json
+++ b/packages/query-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liquescent/log-correlator-query-parser",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "PromQL-style query parser for log correlation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
Bump all package versions to 0.0.7 for npm release.

## Changes
- Version bump from 0.0.6 to 0.0.7 in all packages
- Updated README.md with new version
- Updated package-lock.json

## Release Notes
This release includes:
- Stream name support for Graylog adapter
- Security fixes for CodeQL vulnerabilities (ReDoS prevention)
- Complete removal of vulnerable regex patterns